### PR TITLE
Adds region support as requested in #12

### DIFF
--- a/cmd/devices/get.go
+++ b/cmd/devices/get.go
@@ -90,7 +90,7 @@ func getDevice(token string, serialNumber string) (Device, error) {
 		return Device{}, fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", "https://api-us.vicohome.io/device/selectsingledevice", bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequest("POST", GetBaseURL()+"/device/selectsingledevice", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return Device{}, fmt.Errorf("error creating request: %w", err)
 	}

--- a/cmd/devices/list.go
+++ b/cmd/devices/list.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
+	"os"
 	"github.com/dydx/vico-cli/pkg/auth"
 	"github.com/spf13/cobra"
 )
@@ -91,7 +91,12 @@ var listCmd = &cobra.Command{
 func init() {
 	listCmd.Flags().StringVar(&outputFormat, "format", "table", "Output format (table or json)")
 }
-
+func GetCountry() string {
+if v := os.Getenv("VICOHOME_COUNTRY"); v != "" {
+return v
+}
+return "US"
+}
 // listDevices fetches all devices associated with the user's account from the Vicohome API.
 // It takes an authentication token and returns a slice of Device objects and any error encountered.
 // This function handles the API request, response parsing, and error handling including
@@ -99,7 +104,7 @@ func init() {
 func listDevices(token string) ([]Device, error) {
 	req := DeviceListRequest{
 		Language:  "en",
-		CountryNo: "US",
+		CountryNo: GetCountry(),
 	}
 
 	reqBody, err := json.Marshal(req)
@@ -107,7 +112,7 @@ func listDevices(token string) ([]Device, error) {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", "https://api-us.vicohome.io/device/listuserdevices", bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequest("POST", GetBaseURL()+"/device/listuserdevices", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}

--- a/cmd/devices/root.go
+++ b/cmd/devices/root.go
@@ -6,6 +6,7 @@ package devices
 
 import (
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var devicesCmd = &cobra.Command{
@@ -18,6 +19,12 @@ func init() {
 	// Add subcommands
 	devicesCmd.AddCommand(listCmd)
 	devicesCmd.AddCommand(getCmd)
+}
+func GetBaseURL() string {
+if v := os.Getenv("VICOHOME_BASE_URL"); v != "" {
+return v
+}
+return "https://api-us.vicohome.io"
 }
 
 // GetDevicesCmd returns the devices command that provides access to device-related subcommands.

--- a/cmd/events/get.go
+++ b/cmd/events/get.go
@@ -91,7 +91,7 @@ func getEvent(token string, traceID string) (Event, error) {
 		return Event{}, fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", "https://api-us.vicohome.io/library/newselectsinglelibrary", bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequest("POST", GetBaseURL()+"/library/newselectsinglelibrary", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return Event{}, fmt.Errorf("error creating request: %w", err)
 	}

--- a/cmd/events/list.go
+++ b/cmd/events/list.go
@@ -160,7 +160,7 @@ func fetchEvents(token string, request Request) ([]Event, error) {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", "https://api-us.vicohome.io/library/newselectlibrary", bytes.NewBuffer(reqBody))
+	req, err := http.NewRequest("POST", GetBaseURL()+"/library/newselectlibrary", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}

--- a/cmd/events/root.go
+++ b/cmd/events/root.go
@@ -6,6 +6,7 @@ package events
 
 import (
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var eventsCmd = &cobra.Command{
@@ -20,7 +21,12 @@ func init() {
 	eventsCmd.AddCommand(getCmd)
 	eventsCmd.AddCommand(searchCmd)
 }
-
+func GetBaseURL() string {
+if v := os.Getenv("VICOHOME_BASE_URL"); v != "" {
+return v
+}
+return "https://api-us.vicohome.io"
+}
 // GetEventsCmd returns the events command that provides access to event-related subcommands.
 // This function is called by the root command to add event functionality to the CLI.
 // It returns the events command with all subcommands (list, get, search) already attached.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -99,6 +99,12 @@ func Authenticate() (string, error) {
 
 	return token, nil
 }
+func GetBaseURL() string {
+if v := os.Getenv("VICOHOME_BASE_URL"); v != "" {
+return v
+}
+return "https://api-us.vicohome.io"
+}
 
 // authenticateDirectly performs authentication to the Vicohome API without using the token cache.
 // It retrieves credentials from environment variables (VICOHOME_EMAIL and VICOHOME_PASSWORD),
@@ -128,7 +134,7 @@ func authenticateDirectly() (string, error) {
 		return "", fmt.Errorf("error marshaling login request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", "https://api-us.vicohome.io/account/login", bytes.NewBuffer(reqBody))
+	req, err := http.NewRequest("POST", GetBaseURL()+"/account/login", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", fmt.Errorf("error creating request: %w", err)
 	}


### PR DESCRIPTION

This pull request introduces greater configurability and flexibility to the API endpoint and country selection logic throughout the CLI tool. The most significant changes are the introduction of environment variable overrides for the Vicohome API base URL and country code, and the refactoring of all HTTP requests to use these dynamic values. This makes the CLI more adaptable to different environments or regions without requiring code changes.

**Configurability improvements:**

* Added a `GetBaseURL()` function in `pkg/auth/auth.go`, `cmd/devices/root.go`, and `cmd/events/root.go` to allow the API base URL to be set via the `VICOHOME_BASE_URL` environment variable, defaulting to `"https://api-us.vicohome.io"` if not set. All HTTP requests in device and event commands now use this function to construct their URLs. [[1]](diffhunk://#diff-0ccbf9a2a7d709b87dbf2f30cc730528c6299d537bf721300d49502cfe521c0aR102-R107) [[2]](diffhunk://#diff-0ccbf9a2a7d709b87dbf2f30cc730528c6299d537bf721300d49502cfe521c0aL131-R137) [[3]](diffhunk://#diff-c4be76c7133bfdc4cb8c18d71e90145237e4910c1bbb5f1289b55b249d09e2b8R23-R28) [[4]](diffhunk://#diff-d582eb3b1c14c2beff3d55637a76429ce45d78e8ec23d4bca620ea3c2b57e0ceL93-R93) [[5]](diffhunk://#diff-ffaaf28e5df21af71a1122601507c7428b0c84a069a4cfaeed2ca14a71dc963bL94-R115) [[6]](diffhunk://#diff-784954300330a3f86744346eac4c2ac4c01002a558bf7e3543f5a81f022a60bbL94-R94) [[7]](diffhunk://#diff-aa79d33ef47a03f49fba2aa209833be9bb899317cb5ea49a3da72af189467848L163-R163) [[8]](diffhunk://#diff-2035cfc74bccf152159bb2b9e4db01b6556a26f2626d586a39152380f53b2000L23-R29)

* Added a `GetCountry()` function in `cmd/devices/list.go` to allow the country code to be set via the `VICOHOME_COUNTRY` environment variable, defaulting to `"US"` if not set. The device list request now uses this function for the `CountryNo` parameter.

**Dependency and import updates:**

* Added `os` package imports in files where environment variable access is required. [[1]](diffhunk://#diff-c4be76c7133bfdc4cb8c18d71e90145237e4910c1bbb5f1289b55b249d09e2b8R9) [[2]](diffhunk://#diff-ffaaf28e5df21af71a1122601507c7428b0c84a069a4cfaeed2ca14a71dc963bL8-R8) [[3]](diffhunk://#diff-2035cfc74bccf152159bb2b9e4db01b6556a26f2626d586a39152380f53b2000R9)

These changes make the CLI more robust for multi-region or custom deployments and improve maintainability by centralizing configuration logic.